### PR TITLE
Secure Backup Polishing

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -124,8 +124,11 @@ workbox_config := "./src/Javascript/workbox.config.cjs"
 @dev-build: clean html css javascript-dev elm-dev fonts favicons manifests images
 
 
+@build: clean html css elm-production javascript-prod fonts favicons manifests images production-service-worker
+
+
 @production-build:
-	just config=production clean html css elm-production javascript-prod fonts favicons manifests images production-service-worker
+	just config=production build
 
 
 @production-service-worker:

--- a/src/Application/Authenticated.elm
+++ b/src/Application/Authenticated.elm
@@ -539,7 +539,7 @@ viewBackup model =
                 , [ View.Dashboard.sectionParagraph
                         [ Html.text "The dashboard will need access permissions to your private files to create a secure backup." ]
                   , View.Backup.buttonGroup
-                        [ View.Backup.askForPermissionButton (AuthenticatedMsg BackupAskForPermission)
+                        [ View.Backup.buttonAskForPermission (AuthenticatedMsg BackupAskForPermission)
                         ]
                   ]
                 ]
@@ -586,7 +586,7 @@ viewBackupPermissioned model =
             List.concat
                 [ viewBackupInfo model
                 , [ View.Backup.buttonGroup
-                        [ View.Backup.secureBackupButton (AuthenticatedMsg BackupStart)
+                        [ View.Backup.buttonSecureBackup (AuthenticatedMsg BackupStart)
                         ]
                   ]
                 , case model.backupState of
@@ -636,13 +636,13 @@ viewBackupShowingKey model backup =
             , onToggleVisibility = AuthenticatedMsg (BackupToggleKeyVisibility (not backup.visible))
             }
         , View.Backup.twoOptions
-            (View.Backup.storeInPasswordManagerButton
+            (View.Backup.buttonStoreInPasswordManager
                 { username = model.username
                 , key = backup.key
                 , onStore = AuthenticatedMsg BackupStoreInBrowser
                 }
             )
-            (View.Backup.downloadKeyButton
+            (View.Backup.buttonDownloadKey
                 { key = backup.key
                 }
             )

--- a/src/Application/Authenticated.elm
+++ b/src/Application/Authenticated.elm
@@ -593,7 +593,7 @@ viewBackupShowingKey model backup =
             , onToggleVisibility = AuthenticatedMsg (BackupToggleKeyVisibility (not backup.visible))
             }
         , View.Backup.twoOptions
-            (View.Backup.storeInBrowserButton
+            (View.Backup.storeInPasswordManagerButton
                 { username = model.username
                 , key = backup.key
                 , onStore = AuthenticatedMsg BackupStoreInBrowser

--- a/src/Application/Authenticated.elm
+++ b/src/Application/Authenticated.elm
@@ -163,7 +163,7 @@ update navKey msg globalModel model =
         BackupReceivedKey key ->
             case model.backupState of
                 BackupFetchingKey ->
-                    ( { model | backupState = BackupFetchedKey key }
+                    ( { model | backupState = BackupFetchedKey { key = key, visible = False } }
                     , Cmd.none
                     )
 
@@ -201,6 +201,18 @@ update navKey msg globalModel model =
                 BackupFetchedKey _ ->
                     ( model
                     , Navigation.pushUrl navKey (Url.toString globalModel.url)
+                    )
+
+                _ ->
+                    ( model
+                    , Cmd.none
+                    )
+
+        BackupToggleKeyVisibility to ->
+            case model.backupState of
+                BackupFetchedKey backup ->
+                    ( { model | backupState = BackupFetchedKey { backup | visible = to } }
+                    , Cmd.none
                     )
 
                 _ ->
@@ -557,8 +569,8 @@ backupKeyInputFieldId =
     "backup-key"
 
 
-viewBackupShowingKey : AuthenticatedModel -> String -> List (Html Msg)
-viewBackupShowingKey model key =
+viewBackupShowingKey : AuthenticatedModel -> { key : String, visible : Bool } -> List (Html Msg)
+viewBackupShowingKey model backup =
     [ View.Dashboard.sectionParagraph
         [ Html.text "This is your secure backup."
         , Html.br [] []
@@ -575,18 +587,20 @@ viewBackupShowingKey model key =
     , View.Dashboard.sectionGroup []
         [ View.Backup.keyTextField
             { id = backupKeyInputFieldId
-            , key = key
+            , key = backup.key
+            , keyVisible = backup.visible
             , onCopyToClipboard = AuthenticatedMsg BackupCopyToClipboard
+            , onToggleVisibility = AuthenticatedMsg (BackupToggleKeyVisibility (not backup.visible))
             }
         , View.Backup.twoOptions
             (View.Backup.storeInBrowserButton
                 { username = model.username
-                , key = key
+                , key = backup.key
                 , onStore = AuthenticatedMsg BackupStoreInBrowser
                 }
             )
             (View.Backup.downloadKeyButton
-                { key = key
+                { key = backup.key
                 }
             )
         ]

--- a/src/Application/Authenticated.elm
+++ b/src/Application/Authenticated.elm
@@ -166,6 +166,11 @@ update navKey msg globalModel model =
                     , Cmd.none
                     )
 
+        BackupCancel ->
+            ( { model | backupState = BackupWaiting }
+            , Cmd.none
+            )
+
         BackupReceivedKey key ->
             case model.backupState of
                 BackupFetchingKey ->
@@ -513,7 +518,19 @@ viewBackup model =
                 _ ->
                     False
     in
-    [ View.Dashboard.heading [ Html.text "Secure Backup" ]
+    [ View.Dashboard.heading
+        (List.append [ Html.span [] [ Html.text "Secure Backup" ] ]
+            (case model.backupState of
+                BackupFetchingKey ->
+                    [ View.Backup.buttonBackupCancel (AuthenticatedMsg BackupCancel) ]
+
+                BackupFetchedKey _ ->
+                    [ View.Backup.buttonBackupCancel (AuthenticatedMsg BackupCancel) ]
+
+                _ ->
+                    []
+            )
+        )
     , View.Common.sectionSpacer
     , View.Dashboard.section []
         (if hasPrivateFilesystemPermissions model.permissions then

--- a/src/Application/Authenticated.elm
+++ b/src/Application/Authenticated.elm
@@ -521,14 +521,11 @@ viewBackup model =
     [ View.Dashboard.heading
         (List.append [ Html.span [] [ Html.text "Secure Backup" ] ]
             (case model.backupState of
-                BackupFetchingKey ->
-                    [ View.Backup.buttonBackupCancel (AuthenticatedMsg BackupCancel) ]
-
-                BackupFetchedKey _ ->
-                    [ View.Backup.buttonBackupCancel (AuthenticatedMsg BackupCancel) ]
+                BackupWaiting ->
+                    []
 
                 _ ->
-                    []
+                    [ View.Backup.buttonBackupCancel (AuthenticatedMsg BackupCancel) ]
             )
         )
     , View.Common.sectionSpacer

--- a/src/Application/Common.elm
+++ b/src/Application/Common.elm
@@ -8,3 +8,12 @@ when predicate list =
 
     else
         []
+
+
+ifThenElse : Bool -> a -> a -> a
+ifThenElse b t f =
+    if b then
+        t
+
+    else
+        f

--- a/src/Application/Radix.elm
+++ b/src/Application/Radix.elm
@@ -67,7 +67,7 @@ type alias AuthenticatedModel =
 type BackupState
     = BackupWaiting
     | BackupFetchingKey
-    | BackupFetchedKey String
+    | BackupFetchedKey { key : String, visible : Bool }
     | BackupError
 
 
@@ -134,6 +134,7 @@ type AuthenticatedMsg
     | BackupFetchKeyError String
     | BackupCopyToClipboard
     | BackupStoreInBrowser
+    | BackupToggleKeyVisibility Bool
       -- App List
     | FetchedAppList Json.Value
     | DropzonePublishStart

--- a/src/Application/Radix.elm
+++ b/src/Application/Radix.elm
@@ -131,6 +131,7 @@ type AuthenticatedMsg
       -- Backup
     | BackupAskForPermission
     | BackupStart
+    | BackupCancel
     | BackupReceivedKey String
     | BackupFetchKeyError String
     | BackupCopyToClipboard

--- a/src/Application/Radix.elm
+++ b/src/Application/Radix.elm
@@ -68,6 +68,7 @@ type BackupState
     = BackupWaiting
     | BackupFetchingKey
     | BackupFetchedKey { key : String, visible : Bool }
+    | BackupStoredInPasswordManager { key : String }
     | BackupError
 
 

--- a/src/Application/View/Backup.elm
+++ b/src/Application/View/Backup.elm
@@ -1,5 +1,6 @@
 module View.Backup exposing (..)
 
+import Common
 import Css
 import FeatherIcons
 import Html.Styled exposing (..)
@@ -100,8 +101,31 @@ secureBackupButton msg =
         }
 
 
-keyTextField : { id : String, key : String, onCopyToClipboard : msg } -> Html msg
+keyTextField :
+    { id : String
+    , key : String
+    , keyVisible : Bool
+    , onToggleVisibility : msg
+    , onCopyToClipboard : msg
+    }
+    -> Html msg
 keyTextField element =
+    let
+        buttonStyle =
+            Css.batch
+                [ dark
+                    [ Css.active [ bg_gray_100 ]
+                    , bg_gray_200
+                    , border_gray_200
+                    , text_gray_600
+                    ]
+                , Css.active [ bg_gray_900 ]
+                , bg_gray_700
+                , border
+                , border_gray_500
+                , text_gray_300
+                ]
+    in
     div
         [ css
             [ sm [ h_10 ]
@@ -120,6 +144,7 @@ keyTextField element =
                 , h_full
                 , rounded_r_none
                 ]
+            , type_ (Common.ifThenElse element.keyVisible "text" "password")
             , readonly True
             , id element.id
             , value element.key
@@ -127,22 +152,37 @@ keyTextField element =
             []
         , button
             [ css
-                [ dark
-                    [ Css.active [ bg_gray_100 ]
-                    , bg_gray_200
-                    , border_gray_200
-                    , text_gray_600
-                    ]
-                , Css.active [ bg_gray_900 ]
-                , bg_gray_700
-                , border
-                , border_gray_500
+                [ buttonStyle
+                , border_r_0
+                , flex
+                , px_4
+                ]
+            , Events.onClick element.onToggleVisibility
+            ]
+            [ View.Common.icon
+                { icon =
+                    Common.ifThenElse element.keyVisible
+                        FeatherIcons.eyeOff
+                        FeatherIcons.eye
+                , size = View.Common.Small
+                , tag =
+                    span
+                        [ css
+                            [ dark [ text_gray_600 ]
+                            , m_auto
+                            , text_gray_300
+                            ]
+                        ]
+                }
+            ]
+        , button
+            [ css
+                [ buttonStyle
                 , flex
                 , flex_row
                 , items_center
                 , px_4
                 , rounded_r
-                , text_gray_300
                 ]
             , Events.onClick element.onCopyToClipboard
             ]

--- a/src/Application/View/Backup.elm
+++ b/src/Application/View/Backup.elm
@@ -239,8 +239,8 @@ twoOptions option1 option2 =
         ]
 
 
-storeInBrowserButton : { onStore : msg, username : String, key : String } -> Html msg
-storeInBrowserButton element =
+storeInPasswordManagerButton : { onStore : msg, username : String, key : String } -> Html msg
+storeInPasswordManagerButton element =
     form
         [ css
             [ sm
@@ -275,7 +275,7 @@ storeInBrowserButton element =
                 , View.Common.primaryButtonStyle
                 ]
             ]
-            [ text "Store in Browser" ]
+            [ text "Store in Password Manager" ]
         ]
 
 

--- a/src/Application/View/Backup.elm
+++ b/src/Application/View/Backup.elm
@@ -309,3 +309,20 @@ downloadKeyButton element =
             }
         , span [ css [ ml_2, mr_auto ] ] [ text "Download" ]
         ]
+
+
+buttonTryAnotherBackupMethod : msg -> Html msg
+buttonTryAnotherBackupMethod msg =
+    View.Common.button
+        { label = "Try Another Backup Method"
+        , isLoading = False
+        , disabled = False
+        , onClick = Just msg
+        , style =
+            Css.batch
+                [ View.Common.primaryButtonStyle
+                , sm [ w_auto ]
+                , w_full
+                ]
+        , spinnerStyle = []
+        }

--- a/src/Application/View/Backup.elm
+++ b/src/Application/View/Backup.elm
@@ -67,8 +67,8 @@ buttonGroup content =
         content
 
 
-askForPermissionButton : msg -> Html msg
-askForPermissionButton msg =
+buttonAskForPermission : msg -> Html msg
+buttonAskForPermission msg =
     View.Common.button
         { isLoading = False
         , disabled = False
@@ -84,8 +84,8 @@ askForPermissionButton msg =
         }
 
 
-secureBackupButton : msg -> Html msg
-secureBackupButton msg =
+buttonSecureBackup : msg -> Html msg
+buttonSecureBackup msg =
     View.Common.button
         { isLoading = False
         , disabled = False
@@ -239,8 +239,8 @@ twoOptions option1 option2 =
         ]
 
 
-storeInPasswordManagerButton : { onStore : msg, username : String, key : String } -> Html msg
-storeInPasswordManagerButton element =
+buttonStoreInPasswordManager : { onStore : msg, username : String, key : String } -> Html msg
+buttonStoreInPasswordManager element =
     form
         [ css
             [ sm
@@ -279,8 +279,8 @@ storeInPasswordManagerButton element =
         ]
 
 
-downloadKeyButton : { key : String } -> Html msg
-downloadKeyButton element =
+buttonDownloadKey : { key : String } -> Html msg
+buttonDownloadKey element =
     a
         [ css
             [ sm

--- a/src/Application/View/Backup.elm
+++ b/src/Application/View/Backup.elm
@@ -326,3 +326,19 @@ buttonTryAnotherBackupMethod msg =
                 ]
         , spinnerStyle = []
         }
+
+
+buttonBackupCancel : msg -> Html msg
+buttonBackupCancel msg =
+    View.Common.button
+        { label = "CANCEL"
+        , onClick = Just msg
+        , isLoading = False
+        , disabled = False
+        , style =
+            Css.batch
+                [ View.Common.uppercaseButtonStyle
+                , ml_auto
+                ]
+        , spinnerStyle = []
+        }

--- a/src/Application/View/Dashboard.elm
+++ b/src/Application/View/Dashboard.elm
@@ -177,6 +177,7 @@ heading headingItems =
             , flex_wrap
             , font_display
             , items_center
+            , max_w_3xl
             , px_10
             , py_5
             , text_2xl


### PR DESCRIPTION
* Make the read key invisible by default
* Include a toggle button for showing the read key
* Rename "Store in Browser" to "Store in Password Manager"
* Give the user an improved flow for "store in password manager" (add another wizard step)
* Add a button to cancel the backup process
