### PR TITLE
Bump Niv, add node 16 & pnpm/pnpx 6.x

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "ba57d5a29b4e0f2085917010380ef3ddc3cf380f",
-        "sha256": "1kpsvc53x821cmjg1khvp1nz7906gczq8mp83664cr15h94sh8i4",
+        "rev": "e0ca65c81a2d7a4d82a189f1e23a48d59ad42070",
+        "sha256": "1pq9nh1d8nn3xvbdny8fafzw87mj7gsmp6pxkdl65w2g18rmcmzx",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/ba57d5a29b4e0f2085917010380ef3ddc3cf380f.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/e0ca65c81a2d7a4d82a189f1e23a48d59ad42070.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3193b24e448c5a7d8434db56dead638f53b8cde",
-        "sha256": "0zfvam5jiqbv01iip28gavknv2sazhp386sjzy8v35b38ss7ldbr",
+        "rev": "0747387223edf1aa5beaedf48983471315d95e16",
+        "sha256": "19hpz87vfcr6icxcjdlp2mnk8v5db4l3x32adzc5ynmxvfayg3lr",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b3193b24e448c5a7d8434db56dead638f53b8cde.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0747387223edf1aa5beaedf48983471315d95e16.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,12 @@ let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs {};
 
+  node = pkgs.nodejs-16_x;
+  node_pnpm = pkgs.nodePackages_latest.pnpm;
+
+  pnpm = pkgs.writeScriptBin "pnpm" "${node}/bin/node ${node_pnpm}/lib/node_modules/pnpm/bin/pnpm.cjs $@";
+  pnpx = pkgs.writeScriptBin "pnpx" "${node}/bin/node ${node_pnpm}/lib/node_modules/pnpm/bin/pnpx.cjs $@";
+
 in
 
   pkgs.mkShell {
@@ -14,10 +20,13 @@ in
       pkgs.watchexec
       pkgs.jq
 
-      # Language Specific
+      # Elm
       pkgs.elmPackages.elm
       pkgs.elmPackages.elm-format
-      pkgs.nodePackages.pnpm
+
+      # Node
+      pnpm
+      pnpx
 
     ];
   }

--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,7 @@ in
       pkgs.elmPackages.elm-format
 
       # Node
+      node
       pnpm
       pnpx
 


### PR DESCRIPTION
<img width="473" alt="Screen Shot 2021-06-21 at 07 58 55" src="https://user-images.githubusercontent.com/1052016/122783676-9ef0a400-d266-11eb-9025-133188880d13.png">
<img width="465" alt="Screen Shot 2021-06-21 at 08 04 35" src="https://user-images.githubusercontent.com/1052016/122784463-571e4c80-d267-11eb-8271-3de5f73e9773.png">


* Bumped Niv
* Bound `pnpm` and `pnpx` to clean names rather than needing to run them through `node` explicitly
* ~~I did not expose `node` directly, but we _can_ if that's desirable~~ I'm told that this can't hurt 😛 