### PR TITLE
Fix recovery flow for accounts without filesystems

### DIFF
--- a/src/Javascript/index.d.ts
+++ b/src/Javascript/index.d.ts
@@ -1,0 +1,29 @@
+import * as webnative from "webnative"
+import type FileSystem from "webnative/fs/filesystem"
+
+
+//----------------------------------------
+// GLOBALS / CONFIG
+//----------------------------------------
+
+declare global {
+  const CONFIG_ENVIRONMENT: string
+  const CONFIG_API_ENDPOINT: string
+  const CONFIG_LOBBY: string
+  const CONFIG_USER: string
+
+  interface Window {
+    environment: string
+    endpoints: {
+      api: string
+      lobby: string
+      user: string
+    }
+    webnative: typeof webnative
+    fs: FileSystem
+    // For recovery.ts
+    clearBackup: () => void
+  }
+
+  const Elm: any
+}

--- a/src/Javascript/index.ts
+++ b/src/Javascript/index.ts
@@ -1,35 +1,12 @@
 import * as webnative from "webnative"
 import lodashMerge from "lodash/merge"
 import * as uint8arrays from "uint8arrays"
-import type FileSystem from "webnative/fs/index"
 import type { DirectoryPath, FilePath } from "webnative/path"
 
 
 //----------------------------------------
 // GLOBALS / CONFIG
 //----------------------------------------
-
-declare global {
-  const CONFIG_ENVIRONMENT: string
-  const CONFIG_API_ENDPOINT: string
-  const CONFIG_LOBBY: string
-  const CONFIG_USER: string
-
-  interface Window {
-    environment: string
-    endpoints: {
-      api: string
-      lobby: string
-      user: string
-    }
-    webnative: typeof webnative
-    fs: FileSystem
-    // For recovery.ts
-    clearBackup: () => void
-  }
-
-  const Elm: any
-}
 
 window.environment = CONFIG_ENVIRONMENT
 


### PR DESCRIPTION
We can't assume that a filesystem exists when someone wants to "Regain account access".
Specifically, it doesn't exist when someone creates an account from the fission CLI, without ever linking it to the browser (auth lobby).

So we need to make sure we initialise a filesystem just like what the auth lobby does before we do the awake protocol.
