### PR TITLE
Add rosetta nix override

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,34 +1,36 @@
-let
+{rosetta ? false }:
+  let
 
-  sources = import ./nix/sources.nix;
-  pkgs = import sources.nixpkgs {};
+    overrides = if rosetta then { system = "x86_64-darwin"; } else {};
+    sources = import ./nix/sources.nix;
+    pkgs = import sources.nixpkgs overrides;
 
-  node = pkgs.nodejs-16_x;
-  node_pnpm = pkgs.nodePackages_latest.pnpm;
+    node = pkgs.nodejs-16_x;
+    node_pnpm = pkgs.nodePackages_latest.pnpm;
 
-  pnpm = pkgs.writeScriptBin "pnpm" "${node}/bin/node ${node_pnpm}/lib/node_modules/pnpm/bin/pnpm.cjs $@";
-  pnpx = pkgs.writeScriptBin "pnpx" "${node}/bin/node ${node_pnpm}/lib/node_modules/pnpm/bin/pnpx.cjs $@";
+    pnpm = pkgs.writeScriptBin "pnpm" "${node}/bin/node ${node_pnpm}/lib/node_modules/pnpm/bin/pnpm.cjs $@";
+    pnpx = pkgs.writeScriptBin "pnpx" "${node}/bin/node ${node_pnpm}/lib/node_modules/pnpm/bin/pnpx.cjs $@";
 
-in
+  in
 
-  pkgs.mkShell {
-    buildInputs = [
+    pkgs.mkShell {
+      buildInputs = [
 
-      # Dev Tools
-      pkgs.devd
-      pkgs.just
-      pkgs.watchexec
-      pkgs.jq
-      pkgs.niv
+        # Dev Tools
+        pkgs.devd
+        pkgs.just
+        pkgs.watchexec
+        pkgs.jq
+        pkgs.niv
 
-      # Elm
-      pkgs.elmPackages.elm
-      pkgs.elmPackages.elm-format
+        # Elm
+        pkgs.elmPackages.elm
+        pkgs.elmPackages.elm-format
 
-      # Node
-      node
-      pnpm
-      pnpx
+        # Node
+        node
+        pnpm
+        pnpx
 
-    ];
-  }
+      ];
+    }


### PR DESCRIPTION
## Summary
Adds a rosetta nix override, similar to the other projects.

## Background
I'm sure whoever sees this PR already knows, but for anyone else new to Nix like myself, to use this, Nix must be configured as follows.

Open a terminal, without Rosetta enabled and run the following.
```
# Install Nix, per instructions on their site
sh <(curl -L https://nixos.org/nix/install) --daemon

# Add support for x86 via Rosetta where needed
cat <<EOF | sudo tee -a /etc/nix/nix.conf
extra-platforms = x86_64-darwin
EOF

# Reboot so the config change takes effect, or bounce the daemon.  Then...

cd path/to/dashboard
nix-shell --arg rosetta true
```
